### PR TITLE
fix: sprite-extend-3d use http has been blocked

### DIFF
--- a/github-contributions/index.html
+++ b/github-contributions/index.html
@@ -16,7 +16,7 @@
   <div id="stage"></div>
   <script type="module">
     import {Scene} from 'https://unpkg.com/spritejs/dist/spritejs.esm.js';
-    import {Cube, Light, shaders} from 'http://unpkg.com/sprite-extend-3d/dist/sprite-extend-3d.esm.js';
+    import {Cube, Light, shaders} from 'https://unpkg.com/sprite-extend-3d/dist/sprite-extend-3d.esm.js';
 
     let cache = null;
     async function getData(toDate = new Date()) {


### PR DESCRIPTION
fix: sprite-extend-3d use http has been blocked
![image](https://user-images.githubusercontent.com/41336612/88887544-2a3c0200-d26f-11ea-9284-2f991c31fccb.png)
